### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,25 @@ Lighthouse analyzes performance, accessibility, best practices, and more of your
 
 ## Getting Started
 
-Install this addon by running the following command:
+Install this addon:
 
-`ddev get Metadrop/ddev-lighthouse`
+For DDEV v1.23.5 or above run
+
+```sh
+ddev add-on get Metadrop/ddev-lighthouse
+```
+
+For earlier versions of DDEV run
+
+```sh
+ddev get Metadrop/ddev-lighthouse
+```
 
 Once installed, make sure to restart your ddev project:
 
-`ddev restart`
+```sh
+ddev restart
+```
 
 ### Configuration
 
@@ -33,7 +45,9 @@ This addon uses the `tests/functional/lighthouserc.js` configuration file to cus
 
 To execute Lighthouse tests, simply access your ddev environment and run the following command:
 
-`ddev lighthouse`
+```sh
+ddev lighthouse
+```
 
 Lighthouse will generate detailed reports and save them in the `reports/lighthouse` folder of your project.
 


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.